### PR TITLE
Disable buildPhase when building elm packages

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -12,6 +12,7 @@ rec {
         url = "https://github.com/${name}/archive/${version}.tar.gz";
         sha256 = (fromJSON (readFile elmHashesJson)).${name}.${version};
       };
+      buildPhase = "true";
       installPhase = ''
         mkdir -p $out
         cp -r * $out


### PR DESCRIPTION
This is to prevent some packages like "elm-select", which actually have a Makefile, to confuse the build.

Closes #14 